### PR TITLE
small fix for admin menu icon in redmine 3.4

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -7,7 +7,7 @@ Redmine::Plugin.register :redmine_customize_core_fields do
   author_url 'https://github.com/nanego'
   requires_redmine_plugin :redmine_base_rspec, :version_or_higher => '0.0.4' if Rails.env.test?
   requires_redmine_plugin :redmine_base_deface, :version_or_higher => '0.0.1'
-  menu :admin_menu, :redmine_customize_core_fields, {:controller => 'core_fields', :action => 'index' }, :after => :custom_fields, :caption => :field_core_fields
+  menu :admin_menu, :redmine_customize_core_fields, {:controller => 'core_fields', :action => 'index' }, :after => :custom_fields, :caption => :field_core_fields, html: { class: 'icon' }
   settings :default => { 'override_issue_form' => false},
            :partial => 'settings/redmine_plugin_customize_core_fields'
 end


### PR DESCRIPTION
aligns the misplaced admin menu icon in redmine 3.4